### PR TITLE
Add tests foreigner search inactive for person

### DIFF
--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -15,9 +15,11 @@ export const test = base.extend<{ forEachTest: void }>({
         .getByRole("textbox", { name: "Senha" })
         .fill(process.env.PLAYWRIGHT_GWEB_PASSWORD || "");
       await page.getByRole("button", { name: "Entrar" }).click();
-      await page.waitForURL(
-        "https://app.gdoorweb.com.br/selecionar-conta?origin=login"
-      );
+      //espera carregar a página de selecionar conta
+      await page.getByText('Selecionar conta').click();
+
+      // seleciona a empresa
+      await page.getByRole('combobox', { name: 'Digite para buscar a conta' }).click();
       await page.getByRole("heading", { name: process.env.PLAYWRIGHT_GWEB_ACCOUNT }).click();
       await page.waitForURL(process.env.PLAYWRIGHT_GWEB_URL || "");
       // follows next tests

--- a/tests/registers/person.spec.ts
+++ b/tests/registers/person.spec.ts
@@ -8,7 +8,7 @@ import 'dotenv/config';
 import { Search } from '../types/general/search.type';
 
 // cria uma pessoa para ser cadastrada
-let person: Person = {
+var person: Person = {
   type: 'Pessoa',
   name: "AutoPerson " + faker.person.fullName(),
   surname: "AutoPerson " + faker.person.firstName(),
@@ -40,7 +40,7 @@ let person: Person = {
 }
 
 //cria um vendedor para ser cadastrado
-let seller: Seller = {
+var seller: Seller = {
   type: 'Vendedor',
   name: "AutoSeller " + faker.person.fullName(),
   surname: "AutoSeller " + faker.person.firstName(),
@@ -77,7 +77,7 @@ let seller: Seller = {
 }
 
 // cria uma empresa para ser cadastrada
-let company: Company = {
+var company: Company = {
   type: 'Empresa',
   name: "AutoCompany " + faker.company.name(),
   trade_name: "AutoCompany " + faker.company.name(),
@@ -114,7 +114,7 @@ let company: Company = {
 }
 
 // cria um produtor rural
-let rural_producer: RuralProducer = {
+var rural_producer: RuralProducer = {
   type: 'Produtor Rural',
   name: "AutoRural " + faker.person.fullName(),
   surname: "AutoRural " + faker.person.firstName(),
@@ -145,7 +145,7 @@ let rural_producer: RuralProducer = {
 }
 
 // cria um contador
-let accountant: Accountant = {
+var accountant: Accountant = {
   type: 'Contador',
   name: "AutoAccountant " + faker.person.fullName(),
   surname: "AutoAccountant " + faker.person.firstName(),
@@ -177,7 +177,7 @@ let accountant: Accountant = {
 }
 
 // cria uma transportadora
-let transporter: Transporter = {
+var transporter: Transporter = {
   type: 'Transportador',
   name: "AutoTransporter " + faker.person.fullName(),
   trade_name: "AutoTransporter " + faker.person.firstName(),
@@ -216,7 +216,7 @@ let transporter: Transporter = {
   obs: "AutoTransporter " + faker.lorem.sentences(10, '\n')
 }
 
-let foreigner: Foreigner = {
+var foreigner: Foreigner = {
   type: 'Estrangeiro',
   name: 'AutoForeigner from Gibraltar',
   surname: 'Auto Gibraltarian',
@@ -234,7 +234,7 @@ let foreigner: Foreigner = {
 }
 
 // usuário administrador para ser editado
-let adm = {
+var adm = {
   surname: "Usuário administrador",
   national_document: generateCpf({ format: true }),
   state_document: faker.string.numeric({ length: 7 }),

--- a/tests/registers/person.spec.ts
+++ b/tests/registers/person.spec.ts
@@ -1036,6 +1036,36 @@ test('Should search people', async ({ page }) => {
 
 });
 
+test('Should inactivate AutoPerson', async ({ page }) => {
+  // navega para o menu de pessoa
+  await page.getByRole('button', { name: 'Cadastros' }).click();
+  await page.getByRole('link', { name: 'Pessoas' }).click();
+
+  // pesquisa a pessoa e espera 2 segundos para carregar a lista
+  await page.getByRole('searchbox', { name: 'Digite para buscar...' }).click();
+  await page.getByRole('searchbox', { name: 'Digite para buscar...' }).fill(person.name);
+  await page.waitForTimeout(2000);
+
+  // abre para editar
+  await page.getByRole('heading', { name: new RegExp(person.name) }).click();
+  await page.getByRole('button', { name: 'Editar' }).click();
+
+  //inativa e salva
+  await page.locator('label').filter({ hasText: 'Ativo' }).click();
+  await page.getByRole('button', { name: 'Salvar' }).click();
+
+  // clica no nome para esperar carregar e verifica se está inativo
+  await page.getByRole('heading', { name: person.name }).click();
+  await expect(page.getByText('StatusInativo')).toBeVisible();
+
+  // pesquisa se a pessoa ficou inativa na lista
+  await page.getByRole('link', { name: 'Pessoas' }).click();
+  await page.getByRole('searchbox', { name: 'Digite para buscar...' }).click();
+  await page.getByRole('searchbox', { name: 'Digite para buscar...' }).fill(person.name);
+  await page.waitForTimeout(2000);
+  await expect(page.getByRole('heading', { name: new RegExp('Inativo') })).toBeVisible();
+});
+
 test('Should edit user #2', async ({ page }) => {
   // navega para o cadastro
   await page.goto(process.env.PLAYWRIGHT_GWEB_URL + "/cadastros/pessoas/2/editar");
@@ -1083,7 +1113,7 @@ test('Should delete People', async ({ page }) => {
   await page.getByRole('button', { name: 'Cadastros' }).click();
   await page.getByRole('link', { name: 'Pessoas' }).click();
   await page.waitForTimeout(2000);
-  
+
   // deleta pessoas da lista acima
   for (let i = 0; i < addedData.people.length; i++) {
     const person = addedData.people[i];

--- a/tests/registers/person.spec.ts
+++ b/tests/registers/person.spec.ts
@@ -3,7 +3,7 @@ import { test } from '../helpers/fixtures';
 import { generate as generateCpf } from 'gerador-validador-cpf'
 import { faker } from '@faker-js/faker';
 import { generate as generateCnpj, format as formatCnpj } from 'cnpj';
-import { Person, Company, Seller, RuralProducer, Accountant, Transporter } from '../types/registers/person.type';
+import { Person, Company, Seller, RuralProducer, Accountant, Transporter, Foreigner } from '../types/registers/person.type';
 import 'dotenv/config';
 
 // cria uma pessoa para ser cadastrada
@@ -215,6 +215,23 @@ let transporter: Transporter = {
   obs: "AutoTransporter " + faker.lorem.sentences(10, '\n')
 }
 
+let foreigner: Foreigner = {
+  type: 'Estrangeiro',
+  name: 'Auto Person from Gibraltar',
+  surname: 'Auto Gibraltarian',
+  document: faker.string.numeric({ length: 8 }),
+  birth_date: '01/01/2000',
+  local: 'John Mackintosh Square',
+  district: 'Gibraltar GX11 1AA',
+  number: '1',
+  country: 'Gibraltar',
+  state: 'EX',
+  city_name: 'Exterior',
+  phone: '4934414120',
+  cell: '(49) 9200-11913',
+  fax: '1234567',
+}
+
 // usuário administrador para ser editado
 let adm = {
   surname: "Usuário administrador",
@@ -229,7 +246,7 @@ let adm = {
   city_name: 'Concórdia',
 }
 
-var addedData: { people: (Person | Company | Transporter | Accountant | Seller | RuralProducer)[] } = { people: [] };
+var addedData: { people: (Person | Company | Transporter | Accountant | Seller | RuralProducer | Foreigner)[] } = { people: [] };
 
 test('Should create a new Person', async ({ page }) => {
   //navega para o menu de pessoa
@@ -893,6 +910,65 @@ test('Should create a new transporter', async ({ page }) => {
   await expect.soft(page.getByText('País' + transporter.country)).toBeVisible();
 
   addedData.people.push(transporter);
+});
+
+test('Should create a new foreigner', async ({ page }) => {
+  //navega para o menu de pessoa
+  await page.getByRole('button', { name: 'Cadastros' }).click();
+  await page.getByRole('link', { name: 'Pessoas' }).click();
+
+  // abre o cadastro de uma nova pessoa
+  await page.getByRole('link').filter({ hasText: /^$/ }).click();
+
+  // troca o país para Gibraltar e cidade para Ex
+  await page.getByRole('combobox', { name: 'País' }).click();
+  await page.getByRole('combobox', { name: 'País' }).fill(foreigner.country);
+  await page.getByText(foreigner.country).click();
+  await page.getByRole('combobox', { name: 'Município' }).click();
+  await page.getByText(foreigner.city_name + ' - ' + foreigner.state).click();
+
+  // preenche dados gerais
+  await page.getByRole('textbox', { name: 'Nome' }).click();
+  await page.getByRole('textbox', { name: 'Nome' }).fill(foreigner.name);
+  await page.getByRole('textbox', { name: 'Apelido' }).click();
+  await page.getByRole('textbox', { name: 'Apelido' }).fill(foreigner.surname);
+  await page.getByRole('textbox', { name: 'Documento de identificação' }).click();
+  await page.getByRole('textbox', { name: 'Documento de identificação' }).fill(foreigner.document);
+  await page.getByRole('textbox', { name: 'Data de nascimento' }).click();
+  await page.getByRole('textbox', { name: 'Data de nascimento' }).fill(foreigner.birth_date);
+
+  // preenche o resto do endereço
+  await page.getByRole('textbox', { name: 'Logradouro' }).click();
+  await page.getByRole('textbox', { name: 'Logradouro' }).fill(foreigner.local);
+  await page.getByRole('textbox', { name: 'Número' }).click();
+  await page.getByRole('textbox', { name: 'Número' }).fill(foreigner.number);
+  await page.getByRole('textbox', { name: 'Bairro' }).click();
+  await page.getByRole('textbox', { name: 'Bairro' }).fill(foreigner.district);
+
+  // preenche telefones
+  await page.getByRole('textbox', { name: 'Telefone' }).click();
+  await page.getByRole('textbox', { name: 'Telefone' }).fill(foreigner.phone);
+  await page.getByRole('textbox', { name: 'Celular' }).click();
+  await page.getByRole('textbox', { name: 'Celular' }).fill(foreigner.cell);
+  await page.getByRole('textbox', { name: 'Fax' }).click();
+  await page.getByRole('textbox', { name: 'Fax' }).fill(foreigner.fax);
+
+  //salva a pessoa
+  await page.getByRole('button', { name: 'Salvar' }).click();
+  await page.getByRole('heading', { name: foreigner.name }).click();
+
+
+  // valida os campos na página de visualização pós cadastro
+  await expect.soft(page.getByText('Nome' + foreigner.name)).toBeVisible();
+  await expect.soft(page.getByText('Apelido' + foreigner.surname)).toBeVisible();
+  await expect.soft(page.getByText('Documento de identificação' + foreigner.document)).toBeVisible();
+  await expect.soft(page.getByText('Logradouro' + foreigner.local)).toBeVisible();
+  await expect.soft(page.getByText('Número' + foreigner.number)).toBeVisible();
+  await expect.soft(page.getByText('Bairro' + foreigner.district)).toBeVisible();
+  await expect.soft(page.getByText('Município' + foreigner.city_name)).toBeVisible();
+  await expect.soft(page.getByText('País' + foreigner.country)).toBeVisible();
+
+  addedData.people.push(foreigner);
 });
 
 test('Should edit user #2', async ({ page }) => {

--- a/tests/types/general/search.type.ts
+++ b/tests/types/general/search.type.ts
@@ -1,0 +1,4 @@
+export type Search = {
+    searchFor: string,
+    shouldFind: string
+}

--- a/tests/types/registers/person.type.ts
+++ b/tests/types/registers/person.type.ts
@@ -94,3 +94,20 @@ export type Transporter = BasePerson & {
     cap_kg: string,
   }
 }
+
+export type Foreigner = {
+  type: string,
+  name: string,
+  surname: string,
+  document: string,
+  birth_date: string,
+  local: string;
+  district: string;
+  number: string;
+  country: string;
+  state: string;
+  city_name: string;
+  phone: string;
+  cell: string;
+  fax: string;
+}


### PR DESCRIPTION
Adicionei os testes:
- Criar uma pessoa estrangeira;
- Pesquisar pelos tipos de pesquisa disponíveis na [BDC](https://help.gdoorweb.com.br/pt-br/cadastros/pessoas#lista);
- Inativar uma pessoa e verificar se ela ficou inativa na lista;

Também mudei de `let` para `var` a declaração das variáveis nos testes de pessoas, aparentemente vez ou outra as informações das variáveis (`person`, `company`, etc.) mudavam de um teste pro outro.
Não descobri o motivo com exatidão, mas mudando para `var` isso não aconteceu mais, então suponho que seja algo relacionado à escopo.